### PR TITLE
fix: RoomPreset recall now works like expected

### DIFF
--- a/src/CiscoRoomOsCodec.cs
+++ b/src/CiscoRoomOsCodec.cs
@@ -6170,7 +6170,7 @@ ConnectorID: {2}"
             else
             {
                 _selectedPreset = preset;
-                CiscoRoomPresetRecall();
+                // CiscoRoomPresetRecall();
             }
         }
 


### PR DESCRIPTION
The expected method for recalling a preset is to select a preset with the `CodecRoomPresetSelect` method, then call either the `CodecRoomPresetStore` method to save a preset or the `CodecRoomPresetRecall` method to recall a preset.