### PR TITLE
fix: adds ClearCiscoCodecUiWebViewController method call to clear web…

### DIFF
--- a/src/UserInterface/CiscoCodecUserInterface/MobileControl/McVideoCodecUserInterfaceRouter.cs
+++ b/src/UserInterface/CiscoCodecUserInterface/MobileControl/McVideoCodecUserInterfaceRouter.cs
@@ -224,6 +224,7 @@ namespace epi_videoCodec_ciscoExtended.UserInterface.CiscoCodecUserInterface.Mob
                 {
                     Debug.LogMessage(LogEventLevel.Debug, $"UiMap default room key {_thisUisDefaultRoomKey} is in lockout state", this);
                     _mcTpController.LockedOut = true;
+                    ClearCiscoCodecUiWebViewController();
                     //SendLockout(_thisUisDefaultRoomKey, _primaryRoomKey);
                     _extensionsHandler.UiWebViewChanagedEvent += LockoutUiWebViewChanagedEventHandler;
                     _mcTpController.UisCiscoCodec.EnqueueCommand(UiWebViewDisplay.xCommandStatus());


### PR DESCRIPTION
This pull request introduces a small but significant change to the `HandleRoomCombineScenarioChanged` method in `McVideoCodecUserInterfaceRouter.cs`. The change ensures that the Cisco Codec UI WebView controller is cleared when the room key is in a lockout state.

Key change:

* [`src/UserInterface/CiscoCodecUserInterface/MobileControl/McVideoCodecUserInterfaceRouter.cs`](diffhunk://#diff-a34c314d545593d4c77357376a8c4e4f4a5925d45cd0f1914708ac56bbf4a3faR227): Added a call to `ClearCiscoCodecUiWebViewController()` within the lockout state handling logic to ensure the UI WebView controller is properly cleared