### PR TITLE
fix: update PresenterTrackAvailability check for PT commands

### DIFF
--- a/src/CiscoRoomOsCodec.cs
+++ b/src/CiscoRoomOsCodec.cs
@@ -278,7 +278,20 @@ namespace epi_videoCodec_ciscoExtended
 
 		public bool SpeakerTrackAvailability { get; private set; }
 		public bool SpeakerTrackStatus { get; private set; }
-		public bool PresenterTrackAvailability { get; private set; }
+        
+		private bool _presenterTrackAvailability;
+        public bool PresenterTrackAvailability { 
+			get
+			{ 
+				Debug.Console(0, this, "PresenterTrackAvailability get, PresenterTrackAvailability: {0}", _presenterTrackAvailability);
+				return _presenterTrackAvailability;
+            }
+			private set
+			{ 
+				Debug.Console(0, this, "PresenterTrackAvailability set, PresenterTrackAvailability: {0}", value);
+				_presenterTrackAvailability = value;
+            }
+		}
 		public bool PresenterTrackStatus { get; private set; }
 		public bool WebviewIsVisible { get; private set; }
 		public string PresenterTrackStatusName { get; private set; }
@@ -593,7 +606,10 @@ namespace epi_videoCodec_ciscoExtended
 
 		protected Func<bool> PresenterTrackAvailableFeedbackFunc
 		{
-			get { return () => PresenterTrackAvailability; }
+			get { 
+				Debug.Console(0,this, "PresenterTrackAvailableFeedbackFunc called, PresenterTrackAvailability: {0}", PresenterTrackAvailability);
+                return () => PresenterTrackAvailability; 
+			}
 		}
 
 		protected Func<bool> SpeakerTrackAvailableFeedbackFunc
@@ -1508,7 +1524,9 @@ namespace epi_videoCodec_ciscoExtended
 			};
 			CodecStatus.Status.Cameras.PresenterTrack.Availability.ValueChangedAction += () =>
 			{
-				PresenterTrackAvailableFeedback.FireUpdate();
+                Debug.Console(0, this, "CodecStatus.Status.Cameras.PresenterTrack.Availability.ValueChangedAction = {0}", CodecStatus.Status.Cameras.PresenterTrack.Availability.Value);
+                PresenterTrackAvailability = CodecStatus.Status.Cameras.PresenterTrack.Availability.BoolValue;
+                PresenterTrackAvailableFeedback.FireUpdate();
 				CameraAutoModeAvailableFeedback.FireUpdate();
 				OnCameraTrackingCapabilitiesChanged();
 			};
@@ -2883,7 +2901,8 @@ namespace epi_videoCodec_ciscoExtended
 				if (String.IsNullOrEmpty(presenterTrackToken.ToString()))
 					return;
 				var presenterTrackObject = presenterTrackToken as JObject;
-				if (presenterTrackObject == null)
+                Debug.Console(0, this, "PresenterTrackObject: {0}", presenterTrackObject != null ? presenterTrackObject.ToString() : "null");
+                if (presenterTrackObject == null)
 					return;
 				var availabilityToken = presenterTrackObject.SelectToken("Availability.Value");
 				var statusToken = presenterTrackObject.SelectToken("Status.Value");
@@ -6955,7 +6974,7 @@ namespace epi_videoCodec_ciscoExtended
 
 		public void PresenterTrackOff()
 		{
-			if (!CodecStatus.Status.Cameras.PresenterTrack.Availability.BoolValue)
+			if (!PresenterTrackAvailability)
 			{
 				Debug.Console(0, this, "Presenter Track is Unavailable on this Codec");
 				return;
@@ -6970,10 +6989,10 @@ namespace epi_videoCodec_ciscoExtended
 
 		public void PresenterTrackFollow()
 		{
-			if (!CodecStatus.Status.Cameras.PresenterTrack.Availability.BoolValue)
+			if (!PresenterTrackAvailability)
 			{
-				Debug.Console(0, this, "Presenter Track is Unavailable on this Codec");
-				return;
+                Debug.Console(0, this, "Presenter Track is Unavailable on this Codec");
+                return;
 			}
 			if (CameraIsOffFeedback.BoolValue)
 			{
@@ -6985,7 +7004,7 @@ namespace epi_videoCodec_ciscoExtended
 
 		public void PresenterTrackBackground()
 		{
-			if (!CodecStatus.Status.Cameras.PresenterTrack.Availability.BoolValue)
+			if (!PresenterTrackAvailability)
 			{
 				Debug.Console(0, this, "Presenter Track is Unavailable on this Codec");
 				return;
@@ -7001,7 +7020,7 @@ namespace epi_videoCodec_ciscoExtended
 
 		public void PresenterTrackPersistent()
 		{
-			if (!CodecStatus.Status.Cameras.PresenterTrack.Availability.BoolValue)
+			if (!PresenterTrackAvailability)
 			{
 				Debug.Console(0, this, "Presenter Track is Unavailable on this Codec");
 				return;


### PR DESCRIPTION
This pull request refactors the handling of `PresenterTrackAvailability` in the `src/CiscoRoomOsCodec.cs` file to improve maintainability and debugging. The changes introduce a backing field for `PresenterTrackAvailability`, add detailed logging for related methods and actions, and update conditional checks to use the new property.

### Refactoring `PresenterTrackAvailability`:

* `PresenterTrackAvailability` now uses a private backing field `_presenterTrackAvailability` with custom `get` and `set` methods that include debug logging for better traceability. (`[src/CiscoRoomOsCodec.csL281-R294](diffhunk://#diff-f4e85311093de444178fa51a9b53f51dc9bc177a5341b075c444271caccbc22eL281-R294)`)

### Enhanced Debugging:

* Added debug logging to `PresenterTrackAvailableFeedbackFunc` to log calls and the current value of `PresenterTrackAvailability`. (`[src/CiscoRoomOsCodec.csL596-R612](diffhunk://#diff-f4e85311093de444178fa51a9b53f51dc9bc177a5341b075c444271caccbc22eL596-R612)`)
* Included debug logging in `SetFeedbackActions()` to log changes to `CodecStatus.Status.Cameras.PresenterTrack.Availability`. (`[src/CiscoRoomOsCodec.csR1527-R1528](diffhunk://#diff-f4e85311093de444178fa51a9b53f51dc9bc177a5341b075c444271caccbc22eR1527-R1528)`)
* Added debug logging in `ParsePresenterTrackToken()` to log the parsed `PresenterTrackObject`. (`[src/CiscoRoomOsCodec.csR2904](diffhunk://#diff-f4e85311093de444178fa51a9b53f51dc9bc177a5341b075c444271caccbc22eR2904)`)

### Updated Conditional Checks:

* Refactored methods (`PresenterTrackOff`, `PresenterTrackFollow`, `PresenterTrackBackground`, `PresenterTrackPersistent`) to use the new `PresenterTrackAvailability` property instead of directly accessing `CodecStatus.Status.Cameras.PresenterTrack.Availability.BoolValue`. This simplifies the logic and ensures consistency. (`[[1]](diffhunk://#diff-f4e85311093de444178fa51a9b53f51dc9bc177a5341b075c444271caccbc22eL6958-R6977)`, `[[2]](diffhunk://#diff-f4e85311093de444178fa51a9b53f51dc9bc177a5341b075c444271caccbc22eL6973-R6992)`, `[[3]](diffhunk://#diff-f4e85311093de444178fa51a9b53f51dc9bc177a5341b075c444271caccbc22eL6988-R7007)`, `[[4]](diffhunk://#diff-f4e85311093de444178fa51a9b53f51dc9bc177a5341b075c444271caccbc22eL7004-R7023)`)CodecStatus was not updating.  PresenterTrackAvailability is the source of truth.  Traced with console statements not commited