### PR TITLE
fix: fixes AddExternalSource method to properly set connector ID

### DIFF
--- a/src/CiscoRoomOsCodec.cs
+++ b/src/CiscoRoomOsCodec.cs
@@ -7426,10 +7426,27 @@ namespace epi_videoCodec_ciscoExtended
 			PepperDash.Essentials.Devices.Common.VideoCodec.Cisco.eExternalSourceType type
 		)
 		{
-			int id = 2;
-			if (connectorId.ToLower() == "hdmiin3")
+			var id = 0;
+			switch (connectorId.ToLower())
 			{
-				id = 3;
+				case "hdmiin1":
+					id = 1;
+					break;
+				case "hdmiin2":
+					id = 2;
+					break;
+				case "hdmiin3":
+					id = 3;
+					break;
+				case "hdmiin4":
+					id = 4;
+					break;
+				case "hdmiin5":
+					id = 5;
+					break;
+				default:
+					id = 2;
+					break;
 			}
 			EnqueueCommand(
 				string.Format(


### PR DESCRIPTION
This pull request refactors the `AddExternalSource` method in the `src/CiscoRoomOsCodec.cs` file to improve clarity and flexibility when determining the `id` based on the `connectorId`. The key change replaces a conditional check with a `switch` statement to handle multiple `connectorId` values.

### Refactor for clarity and flexibility:
* [`src/CiscoRoomOsCodec.cs`](diffhunk://#diff-f4e85311093de444178fa51a9b53f51dc9bc177a5341b075c444271caccbc22eL7429-R7449): Replaced the conditional check for `connectorId` with a `switch` statement, allowing for more explicit handling of multiple HDMI input cases (`hdmiin1` through `hdmiin5`) and a default fallback to `id = 2`.