### PR TITLE
feat: enhance web view handling

### DIFF
--- a/src/UserInterface/CiscoCodecUserInterface.cs
+++ b/src/UserInterface/CiscoCodecUserInterface.cs
@@ -82,18 +82,6 @@ namespace PepperDash.Essentials.Plugin.CiscoRoomOsCodec.UserInterface
 
             Parent.UiExtensionsHandler = UiExtensionsHandler;
 
-            // Parent.IsReadyChange += (s, a) =>
-            // {
-            //     if (!Parent.IsReady) return;
-
-            //     var msg = UiExtensions != null ? "Initializing Video Codec UI Extensions" : "No Ui Extensions in config";
-
-            //     this.LogDebug(msg);
-
-            //     UiExtensions.Initialize(this, Parent.EnqueueCommand);
-
-            //     this.LogDebug("Video Codec UI Extensions Handler Initializing");
-            // };
             return;
         }
     }

--- a/src/UserInterface/Navigator/NavigatorController.cs
+++ b/src/UserInterface/Navigator/NavigatorController.cs
@@ -137,7 +137,20 @@ namespace PepperDash.Essentials.Plugin.CiscoRoomOsCodec.UserInterface.Navigator
 
         public void ShowWebViewOsd(string url, WebViewDisplayConfig webviewConfig)
         {
-            router.SendWebViewUrl(url, webviewConfig);
+            var uriSuccess = Uri.TryCreate(url, UriKind.RelativeOrAbsolute, out var uri);
+            if (!uriSuccess)
+            {
+                this.LogError("Invalid URL: {url}", url);
+                return;
+            }
+
+            if (uri.IsAbsoluteUri)
+            {
+                router.SendWebViewUrl(uri.ToString(), webviewConfig);
+                return;
+            }
+
+            router.SendWebViewMcUrl(uri.ToString(), webviewConfig);
         }
     }
 }

--- a/src/UserInterface/Navigator/NavigatorLockoutHandler.cs
+++ b/src/UserInterface/Navigator/NavigatorLockoutHandler.cs
@@ -306,7 +306,7 @@ namespace PepperDash.Essentials.Plugin.CiscoRoomOsCodec.UserInterface.Navigator
                             DeviceManager.GetDeviceForKey(primaryRoomKey) is IKeyName room ? room.Name : primaryRoomKey;
             }
 
-            SendCiscoCodecUiToWebViewMcUrl(path, webViewConfig);
+            SendWebViewMcUrl(path, webViewConfig);
         }
 
         private async void VideoCodecUiExtensionsClickedMcEventHandler(
@@ -370,7 +370,7 @@ namespace PepperDash.Essentials.Plugin.CiscoRoomOsCodec.UserInterface.Navigator
 
                 foreach (WebViewDisplayConfig webView in mcPanel.UiWebViewDisplays)
                 {
-                    SendCiscoCodecUiToWebViewMcUrl(mcPanel.MobileControlPath, webView);
+                    SendWebViewMcUrl(mcPanel.MobileControlPath, webView);
                 }
             }
             catch (Exception ex)
@@ -385,7 +385,7 @@ namespace PepperDash.Essentials.Plugin.CiscoRoomOsCodec.UserInterface.Navigator
         /// </summary>
         /// <param name="mcPath"></param>
         /// <param name="webViewConfig"></param>
-        public void SendCiscoCodecUiToWebViewMcUrl(
+        public void SendWebViewMcUrl(
             string mcPath,
             WebViewDisplayConfig webViewConfig, bool prependmcUrl = true
 


### PR DESCRIPTION
This pull request introduces improvements to how WebViews are handled and displayed, particularly for OSD and Navigator targets, and refactors related methods for clarity and correctness. The main changes focus on validating URLs before displaying them, updating method names for consistency, and ensuring correct routing of WebView URLs based on their type.

### WebView Handling Improvements

* Added URL validation for OSD WebView targets in `CiscoCodec.cs`, ensuring only absolute URLs are accepted and logging errors for invalid URLs.
* Updated `NavigatorController.ShowWebViewOsd` to validate the URL and route absolute URLs to `SendWebViewUrl`, while relative URLs are sent to `SendWebViewMcUrl`.

### Refactoring for Consistency

* Renamed `SendCiscoCodecUiToWebViewMcUrl` to `SendWebViewMcUrl` in `NavigatorLockoutHandler.cs` and updated all references for clarity and consistency. [[1]](diffhunk://#diff-bd4c4d162d1f0adf830faa50d4979e3e4b60e0a3f208523d23539cdee2ae1fafL309-R309) [[2]](diffhunk://#diff-bd4c4d162d1f0adf830faa50d4979e3e4b60e0a3f208523d23539cdee2ae1fafL373-R373) [[3]](diffhunk://#diff-bd4c4d162d1f0adf830faa50d4979e3e4b60e0a3f208523d23539cdee2ae1fafL388-R388)

### Code Cleanup

* Removed commented-out initialization logic for UI extensions in `CiscoCodecUserInterface.cs` to clean up unused code.

### Dependency Updates

* Added a missing namespace import for `NavigatorController` in `CiscoCodec.cs` to support new functionality.The ShowWebView method now checks if the target is OSD and directly sends the command to show the webview if it is.

If the target is NOT OSD, then the codec finds the first navigator who's parent codec has the same key, and calls that navigator's ShowWebViewOsd method.

The ShowWebViewOsd method will then parse the URL, figure out if it's a relative or absolute URL, and use the appropriate method to handle showing the webview.