### PR TITLE
fix: reset action key after use

### DIFF
--- a/src/UserInterface/Navigator/NavigatorLockoutHandler.cs
+++ b/src/UserInterface/Navigator/NavigatorLockoutHandler.cs
@@ -404,14 +404,19 @@ namespace PepperDash.Essentials.Plugin.CiscoRoomOsCodec.UserInterface.Navigator
                             continue;
                         }
 
-                        if (action.DeviceKey == defaultRoomKey && action.DeviceKey != currentScenarioRoomKey)
+                        var configDeviceKey = action.DeviceKey;
+
+                        if (action.DeviceKey == defaultRoomKey && defaultRoomKey != currentScenarioRoomKey)
                         {
                             this.LogInformation("Sending action {ActionId} to primary room {PrimaryRoomId}", action.MethodName, currentScenarioRoomKey);
                             action.DeviceKey = currentScenarioRoomKey;
                         }
 
-                        this.LogDebug("Running DeviceAction {MethodName}", action.MethodName);
+                        this.LogDebug("Running DeviceAction {MethodName} on device {key}", action.MethodName, action.DeviceKey);
                         await DeviceJsonApi.DoDeviceActionAsync(action);
+
+                        this.LogInformation("Resetting action deviceKey to config value");
+                        action.DeviceKey = configDeviceKey;
                     }
                 }
 


### PR DESCRIPTION
This pull request updates the device action handling logic in `NavigatorLockoutHandler.cs` to improve logging and ensure device keys are correctly managed during scenario execution. The main changes focus on enhancing traceability and preventing unintended side effects when modifying device keys.

**Device action handling improvements:**

* The check for updating `action.DeviceKey` now compares `defaultRoomKey` to `currentScenarioRoomKey`, ensuring actions are sent to the correct room.
* Added a log entry to show which device key an action is being run on, improving traceability.
* After executing the device action, the `DeviceKey` is reset to its original configuration value to prevent side effects in subsequent operations.