### PR TITLE
fix: add panel clicked event subscription to feedback list

### DIFF
--- a/src/CiscoCodec.cs
+++ b/src/CiscoCodec.cs
@@ -1813,6 +1813,9 @@ namespace PepperDash.Essentials.Plugin.CiscoRoomOsCodec
 				+ "Status/Network/Ethernet/MacAddress"
 				+ Delimiter
 				+ prefix
+				+ "/Event/UserInterface/Extensions/Panel/Clicked"
+				+ Delimiter
+                + prefix
 				+ "/Event/CallDisconnect"
 				+ Delimiter;
 			// Keep CallDisconnect last to detect when feedback registration completes correctly


### PR DESCRIPTION
This pull request introduces a minor update to the feedback registration logic in `CiscoCodec.cs`. The change adds support for registering feedback on user interface panel click events.

* Feedback registration now includes the `/Event/UserInterface/Extensions/Panel/Clicked` event, enabling handling of panel click actions.