### PR TITLE
feat: enhance panel feedback handling to support multiple feedback

### DIFF
--- a/src/UserInterface/Config/Panel.cs
+++ b/src/UserInterface/Config/Panel.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Xml.Serialization;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
@@ -140,6 +141,80 @@ namespace PepperDash.Essentials.Plugin.CiscoRoomOsCodec.UserInterface.Config
         [JsonProperty("panelFeedback", NullValueHandling = NullValueHandling.Ignore)]
         [XmlIgnore]
         public PanelFeedback PanelFeedback { get; set; }
+
+        /// <summary>
+        /// Collection of feedback configurations for the panel.
+        /// This property allows multiple feedback sources to control different aspects of the panel.
+        /// Supports both numbered feedback properties (panelFeedback1, panelFeedback2, etc.) and the collection.
+        /// </summary>
+        [JsonIgnore]
+        [XmlIgnore]
+        public List<PanelFeedback> PanelFeedbacks { get; set; } = new List<PanelFeedback>();
+
+        /// <summary>
+        /// First additional feedback configuration.
+        /// </summary>
+        [JsonProperty("panelFeedback1", NullValueHandling = NullValueHandling.Ignore)]
+        [XmlIgnore]
+        public PanelFeedback PanelFeedback1 { get; set; }
+
+        /// <summary>
+        /// Second additional feedback configuration.
+        /// </summary>
+        [JsonProperty("panelFeedback2", NullValueHandling = NullValueHandling.Ignore)]
+        [XmlIgnore]
+        public PanelFeedback PanelFeedback2 { get; set; }
+
+        /// <summary>
+        /// Third additional feedback configuration.
+        /// </summary>
+        [JsonProperty("panelFeedback3", NullValueHandling = NullValueHandling.Ignore)]
+        [XmlIgnore]
+        public PanelFeedback PanelFeedback3 { get; set; }
+
+        /// <summary>
+        /// Fourth additional feedback configuration.
+        /// </summary>
+        [JsonProperty("panelFeedback4", NullValueHandling = NullValueHandling.Ignore)]
+        [XmlIgnore]
+        public PanelFeedback PanelFeedback4 { get; set; }
+
+        /// <summary>
+        /// Fifth additional feedback configuration.
+        /// </summary>
+        [JsonProperty("panelFeedback5", NullValueHandling = NullValueHandling.Ignore)]
+        [XmlIgnore]
+        public PanelFeedback PanelFeedback5 { get; set; }
+
+        /// <summary>
+        /// Gets all configured panel feedbacks (including the legacy single feedback and numbered feedbacks).
+        /// </summary>
+        /// <returns>Collection of all non-null panel feedback configurations.</returns>
+        public IEnumerable<PanelFeedback> GetAllPanelFeedbacks()
+        {
+            var feedbacks = new List<PanelFeedback>();
+            
+            // Add legacy single feedback for backward compatibility
+            if (PanelFeedback != null)
+                feedbacks.Add(PanelFeedback);
+            
+            // Add numbered feedbacks
+            if (PanelFeedback1 != null)
+                feedbacks.Add(PanelFeedback1);
+            if (PanelFeedback2 != null)
+                feedbacks.Add(PanelFeedback2);
+            if (PanelFeedback3 != null)
+                feedbacks.Add(PanelFeedback3);
+            if (PanelFeedback4 != null)
+                feedbacks.Add(PanelFeedback4);
+            if (PanelFeedback5 != null)
+                feedbacks.Add(PanelFeedback5);
+            
+            // Add any feedbacks from the collection
+            feedbacks.AddRange(PanelFeedbacks ?? new List<PanelFeedback>());
+            
+            return feedbacks;
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
This pull request adds support for configuring multiple feedback sources per panel, replacing the previous single-feedback approach. The changes update both the configuration model and all relevant feedback handling logic to work with collections of feedbacks, improving flexibility and backward compatibility.

**Panel feedback configuration model updates:**

* Added new properties to the `Panel` class in `Panel.cs` to support multiple feedback configurations: a `PanelFeedbacks` collection and five individually numbered feedback properties (`PanelFeedback1` through `PanelFeedback5`). Also introduced the `GetAllPanelFeedbacks()` method to aggregate all feedbacks, including legacy and new properties.

**Feedback registration and event handling logic:**

* Updated feedback registration and unregistration methods in `PanelsHandler.cs` to iterate over all feedbacks returned by `GetAllPanelFeedbacks()`, ensuring all configured feedbacks are correctly registered/unregistered for device events. [[1]](diffhunk://#diff-dcf2f34e34360e7a6d280b1a0d8875e26645d43b5da77949b1489bba7dbead54L160-R172) [[2]](diffhunk://#diff-dcf2f34e34360e7a6d280b1a0d8875e26645d43b5da77949b1489bba7dbead54L183-R198) [[3]](diffhunk://#diff-dcf2f34e34360e7a6d280b1a0d8875e26645d43b5da77949b1489bba7dbead54L272-R290) [[4]](diffhunk://#diff-dcf2f34e34360e7a6d280b1a0d8875e26645d43b5da77949b1489bba7dbead54L282-R328)
* Refactored feedback event handling to process events for all matching panel-feedback combinations, not just a single feedback per panel. This ensures accurate event handling when multiple feedbacks are configured.

**Subscription logic improvements:**

* Modified the subscription logic to handle multiple feedbacks per panel, returning success only if all feedback subscriptions succeed, and logging detailed errors for each failed feedback subscription. [[1]](diffhunk://#diff-dcf2f34e34360e7a6d280b1a0d8875e26645d43b5da77949b1489bba7dbead54L449-R482) [[2]](diffhunk://#diff-dcf2f34e34360e7a6d280b1a0d8875e26645d43b5da77949b1489bba7dbead54L466-R503) [[3]](diffhunk://#diff-dcf2f34e34360e7a6d280b1a0d8875e26645d43b5da77949b1489bba7dbead54L489-R527)…urces