### PR TITLE
Feature/set inital panel fb states

### DIFF
--- a/src/UserInterface/UserInterfaceExtensions/Panels/PanelsHandler.cs
+++ b/src/UserInterface/UserInterfaceExtensions/Panels/PanelsHandler.cs
@@ -140,15 +140,11 @@ namespace PepperDash.Essentials.Plugin.CiscoRoomOsCodec.UserInterface.UserInterf
             case eFeedbackEventType.TypeString:
               {
                 var value = feedback.StringValue;
-                parent.LogDebug("Panel {panelId} feedback changed: {feedbackKey} = {value}",
-                  panel.PanelId, panelFeedback.FeedbackKey, value);
                 break;
               }
             case eFeedbackEventType.TypeInt:
               {
                 var value = feedback.IntValue;
-                parent.LogDebug("Panel {panelId} feedback changed: {feedbackKey} = {value}",
-                  panel.PanelId, panelFeedback.FeedbackKey, value);
                 break;
               }
           }
@@ -208,6 +204,7 @@ namespace PepperDash.Essentials.Plugin.CiscoRoomOsCodec.UserInterface.UserInterf
       {
         // Delay added to allow feedback states to update before setting panels to current states.  Feedback events are not guaranteed to fire on room combine scenario change, so this ensures panels will be in correct state for new scenario.
         System.Threading.Thread.Sleep(100);
+        RegisterForDeviceFeedback();
         SetPanelStatesToCurrentFeedbackStates();
       });
     }
@@ -348,11 +345,10 @@ namespace PepperDash.Essentials.Plugin.CiscoRoomOsCodec.UserInterface.UserInterf
 
           parent.LogDebug("Registering for feedback {feedbackKey} for panel {panelId}", feedback.Key, panel.PanelId);
 
+          feedback.OutputChange -= HandleFeedbackOutputChange;
           feedback.OutputChange += HandleFeedbackOutputChange;
         }
       }
-
-
     }
 
     private void UpdatePanelProperty(Panel panel, PanelFeedback feedbackConfig, bool value)

--- a/src/UserInterface/UserInterfaceExtensions/Panels/PanelsHandler.cs
+++ b/src/UserInterface/UserInterfaceExtensions/Panels/PanelsHandler.cs
@@ -202,10 +202,17 @@ namespace PepperDash.Essentials.Plugin.CiscoRoomOsCodec.UserInterface.UserInterf
 
       Task.Run(() =>
       {
-        // Delay added to allow feedback states to update before setting panels to current states.  Feedback events are not guaranteed to fire on room combine scenario change, so this ensures panels will be in correct state for new scenario.
-        System.Threading.Thread.Sleep(100);
-        RegisterForDeviceFeedback();
-        SetPanelStatesToCurrentFeedbackStates();
+        try
+        {
+          // Delay added to allow feedback states to update before setting panels to current states.  Feedback events are not guaranteed to fire on room combine scenario change, so this ensures panels will be in correct state for new scenario.
+          System.Threading.Thread.Sleep(100);
+          RegisterForDeviceFeedback();
+          SetPanelStatesToCurrentFeedbackStates();
+        }
+        catch (Exception ex)
+        {
+          parent.LogError("Error handling room combine scenario change: {error}", ex);
+        }
       });
     }
 

--- a/src/UserInterface/UserInterfaceExtensions/Panels/PanelsHandler.cs
+++ b/src/UserInterface/UserInterfaceExtensions/Panels/PanelsHandler.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
+using System.Threading.Tasks;
 using System.Timers;
 using PepperDash.Core;
 using PepperDash.Core.Logging;
@@ -102,13 +103,13 @@ namespace PepperDash.Essentials.Plugin.CiscoRoomOsCodec.UserInterface.UserInterf
 
       RegisterForCombinerFeedback(combiners[0]);
 
-      SetInitialPanelStates();
+      SetPanelStatesToCurrentFeedbackStates();
     }
 
     /// <summary>
     /// Sets the initial states of panels based on their feedback configurations and the current state of the devices they are linked to.
     /// </summary>
-    private void SetInitialPanelStates()
+    private void SetPanelStatesToCurrentFeedbackStates()
     {
 
       foreach (var panel in panelConfigs)
@@ -202,6 +203,13 @@ namespace PepperDash.Essentials.Plugin.CiscoRoomOsCodec.UserInterface.UserInterf
         parent.LogError("UiMap default room key: {DefaultRoomKey}. UiMap must have an entry keyed to default room key with value of room connection for room state {ScenarioKey}", defaultRoomKey, currentScenario.Key);
         return;
       }
+
+      Task.Run(() =>
+      {
+        // Delay added to allow feedback states to update before setting panels to current states.  Feedback events are not guaranteed to fire on room combine scenario change, so this ensures panels will be in correct state for new scenario.
+        System.Threading.Thread.Sleep(100);
+        SetPanelStatesToCurrentFeedbackStates();
+      });
     }
 
     private void UpdateExtension(object sender, ElapsedEventArgs args)


### PR DESCRIPTION
This pull request introduces improvements to the panel state management logic in `PanelsHandler.cs`, focusing on ensuring panels accurately reflect device feedback states during initialization and room combine scenario changes. The changes also refactor feedback handling for clarity and reliability.

Panel state initialization and synchronization:

* Added the `SetPanelStatesToCurrentFeedbackStates` method, which sets the initial states of panels based on their feedback configurations and the current state of linked devices. This method is called during initialization and after room combine scenario changes to ensure panels are up-to-date.
* Modified `HandleRoomCombineScenarioChanged` to asynchronously update device feedback registrations and panel states after a short delay, ensuring panels reflect the correct state after a scenario change.

Feedback handling refactor:

* Introduced the `SetPanelFeedbackState` method to encapsulate logic for updating panel feedback states, improving clarity and maintainability in feedback event handling.
* Ensured that feedback event handlers are properly managed by removing and re-adding the `HandleFeedbackOutputChange` delegate when registering for device feedback, preventing duplicate event subscriptions.

Minor improvements:

* Added missing `using System.Threading.Tasks;` to support asynchronous operations.
* Improved debug logging and code organization in feedback handling methods.