### PR TITLE
Fix/cleanup

### DIFF
--- a/src/CiscoCodec.cs
+++ b/src/CiscoCodec.cs
@@ -1846,13 +1846,13 @@ namespace PepperDash.Essentials.Plugin.CiscoRoomOsCodec
 				+ "/Event/UserInterface/Presentation/ExternalSource/Selected/SourceIdentifier"
 				+ Delimiter
 				+ prefix
-				+ "Status/UserInterface/WebView/Status"
+				+ "/Status/UserInterface/WebView/Status"
 				+ Delimiter
 				+ prefix
 				+ "/Event/UserInterface/WebView/Display"
 				+ Delimiter
 				+ prefix
-				+ "Status/Network/Ethernet/MacAddress"
+				+ "/Status/Network/Ethernet/MacAddress"
 				+ Delimiter
 				+ prefix
 				+ "/Event/UserInterface/Extensions/Panel/Clicked"

--- a/src/UserInterface/Navigator/INavigatorLockoutHandler.cs
+++ b/src/UserInterface/Navigator/INavigatorLockoutHandler.cs
@@ -19,7 +19,7 @@ namespace PepperDash.Essentials.Plugin.CiscoRoomOsCodec.UserInterface.Navigator
         void ClearWebViewOsd();
     }
 
-    internal interface INavigatorLockoutHanderWithPwa : INavigatorLockoutHandler
+    internal interface INavigatorLockoutHandlerWithPwa : INavigatorLockoutHandler
     {
         /// <summary>
         /// Enters PWA mode on the navigator with the specified URL

--- a/src/UserInterface/Navigator/NavigatorController.cs
+++ b/src/UserInterface/Navigator/NavigatorController.cs
@@ -223,7 +223,7 @@ namespace PepperDash.Essentials.Plugin.CiscoRoomOsCodec.UserInterface.Navigator
                         this.LogError("Invalid absolute URL: {url}", url);
                         return;
                     }
-                    pwaRouter.EnterPwaMode(uri.ToString());
+                    pwaRouter.EnterPwaMode(uri.ToString(), false);
                     return;
                 }
 

--- a/src/UserInterface/Navigator/NavigatorController.cs
+++ b/src/UserInterface/Navigator/NavigatorController.cs
@@ -213,7 +213,7 @@ namespace PepperDash.Essentials.Plugin.CiscoRoomOsCodec.UserInterface.Navigator
 
 
 
-            if (router is INavigatorLockoutHanderWithPwa pwaRouter)
+            if (router is INavigatorLockoutHandlerWithPwa pwaRouter)
             {
                 if(isAbsoluteUrl)
                 {
@@ -240,7 +240,7 @@ namespace PepperDash.Essentials.Plugin.CiscoRoomOsCodec.UserInterface.Navigator
         /// </summary>
         public void ExitPwaMode()
         {
-            if (router is INavigatorLockoutHanderWithPwa pwaRouter)
+            if (router is INavigatorLockoutHandlerWithPwa pwaRouter)
             {
                 pwaRouter.ExitPwaMode();
             }

--- a/src/UserInterface/Navigator/NavigatorLockoutHandlerWithPWA.cs
+++ b/src/UserInterface/Navigator/NavigatorLockoutHandlerWithPWA.cs
@@ -28,7 +28,7 @@ namespace PepperDash.Essentials.Plugin.CiscoRoomOsCodec.UserInterface.Navigator
     /// <summary>
     /// Handles Lockout Functionality with Persistent Web App for Navigator Touch Panels
     /// </summary>
-    internal class NavigatorLockoutHandlerWithPWA : IKeyed, INavigatorLockoutHanderWithPwa
+    internal class NavigatorLockoutHandlerWithPWA : IKeyed, INavigatorLockoutHandlerWithPwa
     {
         public const string LOCKOUT_SCENARIO_KEY = "lockout";
         private NavigatorController mcTpController;


### PR DESCRIPTION
This pull request primarily fixes naming inconsistencies and updates method signatures related to the Persistent Web App (PWA) functionality for navigator touch panels. The changes ensure that interface and class names are consistent and that method calls use the correct parameters.

**Naming consistency improvements:**

* Renamed `INavigatorLockoutHanderWithPwa` to `INavigatorLockoutHandlerWithPwa` across the codebase, including in the interface declaration (`src/UserInterface/Navigator/INavigatorLockoutHandler.cs`), type checks, and class implementation (`src/UserInterface/Navigator/NavigatorLockoutHandlerWithPWA.cs`). [[1]](diffhunk://#diff-219890807ec25edd1c8f6d94c8e3eb063f105c7ba7b541bca00547768646d988L22-R22) [[2]](diffhunk://#diff-06ef33008a67b92e5b58c972793a98978199a713e2610e6492ac273c87ba1e80L216-R216) [[3]](diffhunk://#diff-06ef33008a67b92e5b58c972793a98978199a713e2610e6492ac273c87ba1e80L243-R243) [[4]](diffhunk://#diff-a42a98154178c7764bacfaf246aced67ebdb33b9d1a8e2bccfa780a01cb25f28L31-R31)

**Method signature and usage updates:**

* Updated the call to `EnterPwaMode` to include an additional boolean parameter, ensuring the method is invoked with the correct signature (`src/UserInterface/Navigator/NavigatorController.cs`).

**Feedback registration expression fixes:**

* Corrected the feedback registration expression paths by adding missing slashes, ensuring proper event and status monitoring (`src/CiscoCodec.cs`).